### PR TITLE
Multiple RiskModule CashFlowLender

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ typechain-types
 #Hardhat files
 cache
 artifacts
+build
 
 .openzeppelin

--- a/contracts/CashFlowLender.sol
+++ b/contracts/CashFlowLender.sol
@@ -10,6 +10,7 @@ import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/U
 import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 import {SignedQuoteRiskModule} from "@ensuro/core/contracts/SignedQuoteRiskModule.sol";
 import {Policy} from "@ensuro/core/contracts/Policy.sol";
+import {IPolicyPool} from "@ensuro/core/contracts/interfaces/IPolicyPool.sol";
 import {IPolicyHolder} from "@ensuro/core/contracts/interfaces/IPolicyHolder.sol";
 
 /**
@@ -63,14 +64,22 @@ contract CashFlowLender is AccessControlUpgradeable, UUPSUpgradeable, IPolicyHol
     _customer = customer_;
     emit CustomerChanged(customer_);
     // Infinite approval to the PolicyPool to pay the premiums
-    _riskModule.currency().approve(address(_riskModule.policyPool()), type(uint256).max);
+    _currency().approve(address(_pool()), type(uint256).max);
   }
 
   // solhint-disable-next-line no-empty-blocks
   function _authorizeUpgrade(address newImpl) internal view override onlyRole(GUARDIAN_ROLE) {}
 
+  function _pool() internal view returns (IPolicyPool) {
+    return _riskModule.policyPool();
+  }
+
+  function _currency() internal view returns (IERC20Metadata) {
+    return _pool().currency();
+  }
+
   function _balance() internal view returns (uint256) {
-    return _riskModule.currency().balanceOf(address(this));
+    return _currency().balanceOf(address(this));
   }
 
   function _increaseDebt(uint256 amount) internal {
@@ -103,7 +112,7 @@ contract CashFlowLender is AccessControlUpgradeable, UUPSUpgradeable, IPolicyHol
     uint40 quoteValidUntil
   ) external onlyRole(POLICY_CREATOR_ROLE) returns (Policy.PolicyData memory createdPolicy) {
     uint256 balanceBefore = _balance();
-    createdPolicy = _riskModule.newPolicyFull(
+    createdPolicy = riskModule().newPolicyFull(
       payout,
       premium,
       lossProb,
@@ -139,7 +148,7 @@ contract CashFlowLender is AccessControlUpgradeable, UUPSUpgradeable, IPolicyHol
     uint40 quoteValidUntil
   ) external onlyRole(POLICY_CREATOR_ROLE) returns (uint256 policyId) {
     uint256 balanceBefore = _balance();
-    policyId = _riskModule.newPolicy(
+    policyId = riskModule().newPolicy(
       payout,
       premium,
       lossProb,
@@ -180,7 +189,7 @@ contract CashFlowLender is AccessControlUpgradeable, UUPSUpgradeable, IPolicyHol
      * Calls newPolicy instead of newPolicyPaidByHolder because customer == msg.sender. We just keep this method
      * to work as a no-code change replacement of the SignedQuoteRiskModule
      */
-    policyId = _riskModule.newPolicy(
+    policyId = riskModule().newPolicy(
       payout,
       premium,
       lossProb,
@@ -204,7 +213,7 @@ contract CashFlowLender is AccessControlUpgradeable, UUPSUpgradeable, IPolicyHol
         payout -= _debt;
         _decreaseDebt(_debt);
       }
-      _riskModule.currency().safeTransfer(_customer, payout);
+      _currency().safeTransfer(_customer, payout);
     }
   }
 
@@ -212,14 +221,14 @@ contract CashFlowLender is AccessControlUpgradeable, UUPSUpgradeable, IPolicyHol
     Policy.PolicyData calldata policy,
     uint256 payout
   ) external onlyRole(RESOLVER_ROLE) {
-    _riskModule.resolvePolicy(policy, payout);
+    SignedQuoteRiskModule(address(policy.riskModule)).resolvePolicy(policy, payout);
   }
 
   function resolvePolicyFullPayout(
     Policy.PolicyData calldata policy,
     bool customerWon
   ) external onlyRole(RESOLVER_ROLE) {
-    _riskModule.resolvePolicyFullPayout(policy, customerWon);
+    SignedQuoteRiskModule(address(policy.riskModule)).resolvePolicyFullPayout(policy, customerWon);
   }
 
   function onERC721Received(
@@ -250,10 +259,7 @@ contract CashFlowLender is AccessControlUpgradeable, UUPSUpgradeable, IPolicyHol
     uint256,
     uint256 amount
   ) external override returns (bytes4) {
-    require(
-      msg.sender == address(_riskModule.policyPool()),
-      "Only the PolicyPool should call this method"
-    );
+    require(msg.sender == address(_pool()), "Only the PolicyPool should call this method");
     _repayDebtTransferRest(amount);
     return IPolicyHolder.onPayoutReceived.selector;
   }
@@ -282,7 +288,7 @@ contract CashFlowLender is AccessControlUpgradeable, UUPSUpgradeable, IPolicyHol
       amount = Math.min(amount, _balance());
     }
     if (amount > 0) {
-      _riskModule.currency().safeTransfer(destination, amount);
+      _currency().safeTransfer(destination, amount);
       emit Withdrawal(destination, amount);
     }
     return amount;
@@ -305,7 +311,7 @@ contract CashFlowLender is AccessControlUpgradeable, UUPSUpgradeable, IPolicyHol
   /**
    * @dev Returns the address of the wrapped riskModule
    */
-  function riskModule() external view returns (SignedQuoteRiskModule) {
+  function riskModule() public view virtual returns (SignedQuoteRiskModule) {
     return _riskModule;
   }
 
@@ -331,7 +337,7 @@ contract CashFlowLender is AccessControlUpgradeable, UUPSUpgradeable, IPolicyHol
   function repayDebt(uint256 amount) external {
     amount = Math.min(_debt, amount);
     _decreaseDebt(amount);
-    _riskModule.currency().safeTransferFrom(_msgSender(), address(this), amount);
+    _currency().safeTransferFrom(_msgSender(), address(this), amount);
   }
 
   /**

--- a/contracts/CashFlowLender.sol
+++ b/contracts/CashFlowLender.sol
@@ -321,6 +321,9 @@ contract CashFlowLender is AccessControlUpgradeable, UUPSUpgradeable, IPolicyHol
    * Requirements:
    * - Caller has OWNER_ROLE
    *
+   * Emits:
+   * - CustomerChanged
+   *
    * @param customer_ The new address of the customer
    */
   function setCustomer(address customer_) external onlyRole(OWNER_ROLE) {

--- a/contracts/MultiRMCashFlowLender.sol
+++ b/contracts/MultiRMCashFlowLender.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.16;
+import {CashFlowLender} from "./CashFlowLender.sol";
+import {SignedQuoteRiskModule} from "@ensuro/core/contracts/SignedQuoteRiskModule.sol";
+
+/**
+ * @title Multi RiskModule CashFlow Lender Module
+ * @dev Variant of the CashFlowLender that allows to change the target risk module.
+ * @custom:security-contact security@ensuro.co
+ * @author Ensuro
+ */
+contract MultiRMCashFlowLender is CashFlowLender {
+  bytes32 public constant ACTIVE_RM_ADMIN_ROLE = keccak256("ACTIVE_RM_ADMIN_ROLE");
+
+  SignedQuoteRiskModule internal _activeRiskModule;
+
+  event ActiveRiskModuleChanged(SignedQuoteRiskModule newActiveRM);
+
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  // solhint-disable-next-line no-empty-blocks
+  constructor(SignedQuoteRiskModule riskModule_) CashFlowLender(riskModule_) {}
+
+  /**
+   * @dev Returns the address of the riskModule that will be used to create policies
+   */
+  function riskModule() public view override returns (SignedQuoteRiskModule) {
+    return (address(_activeRiskModule) != address(0)) ? _activeRiskModule : _riskModule;
+  }
+
+  function setActiveRiskModule(
+    SignedQuoteRiskModule riskModule_
+  ) external onlyRole(ACTIVE_RM_ADMIN_ROLE) {
+    require(
+      address(riskModule_) == address(0) || riskModule_.policyPool() == _riskModule.policyPool(),
+      "The new risk module has to be part of the same pool"
+    );
+    _activeRiskModule = riskModule_;
+    emit ActiveRiskModuleChanged(address(riskModule_) == address(0) ? _riskModule : riskModule_);
+  }
+}

--- a/contracts/MultiRMCashFlowLender.sol
+++ b/contracts/MultiRMCashFlowLender.sol
@@ -27,6 +27,18 @@ contract MultiRMCashFlowLender is CashFlowLender {
     return (address(_activeRiskModule) != address(0)) ? _activeRiskModule : _riskModule;
   }
 
+  /**
+   * @dev Sets the address of the active riskModule, the one that will receive the new policies. If address(0) is
+   *      received, then the _riskModule indicated in contract constructor will be used.
+   *
+   * Requirements:
+   * - Caller has ACTIVE_RM_ADMIN_ROLE
+   *
+   * Emits:
+   * - ActiveRiskModuleChanged
+   *
+   * @param riskModule_ The new address of the new riskModule
+   */
   function setActiveRiskModule(
     SignedQuoteRiskModule riskModule_
   ) external onlyRole(ACTIVE_RM_ADMIN_ROLE) {

--- a/contracts/MultiRMCashFlowLender.sol
+++ b/contracts/MultiRMCashFlowLender.sol
@@ -37,4 +37,11 @@ contract MultiRMCashFlowLender is CashFlowLender {
     _activeRiskModule = riskModule_;
     emit ActiveRiskModuleChanged(address(riskModule_) == address(0) ? _riskModule : riskModule_);
   }
+
+  /**
+   * @dev This empty reserved space is put in place to allow future versions to add new
+   * variables without shifting down storage in the inheritance chain.
+   * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+   */
+  uint256[49] private __gap;
 }

--- a/contracts/mock/PassportInspector.sol
+++ b/contracts/mock/PassportInspector.sol
@@ -9,7 +9,7 @@ import {IQuadPassportStore} from "@quadrata/contracts/interfaces/IQuadPassportSt
 contract PassportInspector {
   event PassportAttributes(bytes32 attribute, bytes32 value);
 
-  IQuadReader _reader;
+  IQuadReader internal _reader;
 
   constructor(IQuadReader reader) {
     _reader = reader;

--- a/test/test-cash-flow-lender.js
+++ b/test/test-cash-flow-lender.js
@@ -16,10 +16,10 @@ const helpers = require("@nomicfoundation/hardhat-network-helpers");
 
 describe("CashFlowLender contract tests", function () {
   let _A;
-  let lp, cust, signer, resolver, creator, anon;
+  let lp, cust, signer, resolver, creator, anon, guardian;
 
   beforeEach(async () => {
-    [__, lp, cust, signer, resolver, creator, anon, owner] = await hre.ethers.getSigners();
+    [__, lp, cust, signer, resolver, creator, anon, owner, guardian] = await hre.ethers.getSigners();
 
     _A = amountFunction(6);
   });
@@ -61,20 +61,27 @@ describe("CashFlowLender contract tests", function () {
 
     await accessManager.grantComponentRole(rm.address, await rm.PRICER_ROLE(), signer.address);
 
-    const CashFlowLender = await hre.ethers.getContractFactory("CashFlowLender");
+    return { etk, premiumsAccount, rm, pool, accessManager, currency, SignedQuoteRiskModule };
+  }
+
+  async function deployPoolAndCFLFixture(creationIsOpen, contractClass = "CashFlowLender") {
+    const { rm, accessManager, ...others } = await deployPoolFixture(creationIsOpen);
+    const CashFlowLender = await hre.ethers.getContractFactory(contractClass);
     const cfLender = await hre.upgrades.deployProxy(CashFlowLender, [cust.address], {
       kind: "uups",
       unsafeAllow: ["delegatecall"],
       constructorArgs: [rm.address],
     });
+    creationIsOpen = creationIsOpen === undefined ? true : creationIsOpen;
 
-    await accessManager.grantComponentRole(rm.address, await rm.POLICY_CREATOR_ROLE(), cfLender.address);
+    if (!creationIsOpen)
+      await accessManager.grantComponentRole(rm.address, await rm.POLICY_CREATOR_ROLE(), cfLender.address);
     await accessManager.grantComponentRole(rm.address, await rm.RESOLVER_ROLE(), cfLender.address);
     await cfLender.grantRole(await cfLender.OWNER_ROLE(), owner.address);
     await cfLender.grantRole(await cfLender.RESOLVER_ROLE(), resolver.address);
     await cfLender.grantRole(await cfLender.POLICY_CREATOR_ROLE(), creator.address);
-
-    return { etk, premiumsAccount, rm, pool, accessManager, currency, cfLender };
+    await cfLender.grantRole(await cfLender.GUARDIAN_ROLE(), guardian.address);
+    return { rm, accessManager, cfLender, ...others };
   }
 
   function makeQuoteMessage({ rmAddress, payout, premium, lossProb, expiration, policyData, validUntil }) {
@@ -112,16 +119,279 @@ describe("CashFlowLender contract tests", function () {
     );
   }
 
-  it("Creates a policy paid by the CashFlowLender", async () => {
-    const { rm, pool, currency, cfLender } = await helpers.loadFixture(deployPoolFixture);
+  function deployPoolAndCFLFixtureCreationClosed() {
+    return deployPoolAndCFLFixture(false);
+  }
+
+  function deployPoolAndCFLFixtureMultiRMCashFlowLender() {
+    return deployPoolAndCFLFixture(true, "MultiRMCashFlowLender");
+  }
+
+  async function deployPoolAndCFLFixtureUpgradeToMultiRM() {
+    const { cfLender, rm, ...others } = await deployPoolAndCFLFixture();
+    const MultiRMCashFlowLender = await hre.ethers.getContractFactory("MultiRMCashFlowLender");
+    const newImpl = await MultiRMCashFlowLender.deploy(rm.address);
+    await expect(cfLender.connect(anon).upgradeTo(newImpl.address)).to.be.revertedWith(
+      accessControlMessage(anon.address, null, "GUARDIAN_ROLE")
+    );
+    await cfLender.connect(guardian).upgradeTo(newImpl.address);
+    return { cfLender, rm, ...others };
+  }
+
+  async function deployPoolAndCFLFixtureUpgradeToMultiRMChangeRM() {
+    let { cfLender, rm, SignedQuoteRiskModule, pool, premiumsAccount, accessManager, ...others } =
+      await deployPoolAndCFLFixtureUpgradeToMultiRM();
+    // Bind cfLender variable with the MultiRMCashFlowLender ABI
+    cfLender = await hre.ethers.getContractAt("MultiRMCashFlowLender", cfLender.address);
+    const origRM = rm;
+    // Setup a new risk module
+    rm = await addRiskModule(pool, premiumsAccount, SignedQuoteRiskModule, {
+      ensuroFee: 0.03,
+      extraConstructorArgs: [true],
+    });
+
+    await accessManager.grantComponentRole(rm.address, await rm.PRICER_ROLE(), signer.address);
+    await accessManager.grantComponentRole(rm.address, await rm.RESOLVER_ROLE(), cfLender.address);
+    await cfLender.grantRole(await cfLender.ACTIVE_RM_ADMIN_ROLE(), owner.address);
+    await cfLender.connect(owner).setActiveRiskModule(rm.address);
+
+    return { cfLender, rm, pool, premiumsAccount, SignedQuoteRiskModule, accessManager, origRM, ...others };
+  }
+
+  const variants = [
+    { name: "CFL", fixture: deployPoolAndCFLFixture },
+    { name: "CFL creationIsClosed", fixture: deployPoolAndCFLFixtureCreationClosed },
+    { name: "MultiRMCashFlowLender", fixture: deployPoolAndCFLFixtureMultiRMCashFlowLender },
+    { name: "MultiRMCashFlowLender - Upgraded", fixture: deployPoolAndCFLFixtureUpgradeToMultiRM },
+    { name: "MultiRMCashFlowLender - RM Changed", fixture: deployPoolAndCFLFixtureUpgradeToMultiRMChangeRM },
+  ];
+
+  variants.map((variant) => {
+    const _tn = (testName) => `${testName} - ${variant.name}`;
+
+    it(_tn("Creates a policy paid by the CashFlowLender"), async () => {
+      const { rm, pool, currency, cfLender } = await helpers.loadFixture(variant.fixture);
+      const policyParams = await defaultPolicyParams({ rmAddress: rm.address, premium: _A(200) });
+      const quoteMessage = makeQuoteMessage(policyParams);
+      const signature = ethers.utils.splitSignature(await signer.signMessage(ethers.utils.arrayify(quoteMessage)));
+      await expect(newPolicy(cfLender, creator, policyParams, cust, signature)).to.be.revertedWith(
+        "ERC20: transfer amount exceeds balance" // No funds in cfLender
+      );
+      expect(await currency.balanceOf(cfLender.address)).to.be.equal(_A(0));
+      await currency.connect(owner).transfer(cfLender.address, _A(1000));
+      const tx = await newPolicy(cfLender, creator, policyParams, cust, signature);
+      const receipt = await tx.wait();
+      expect(await currency.balanceOf(cfLender.address)).to.be.equal(_A(800)); // 200 spent on the premium
+      expect(await cfLender.currentDebt()).to.be.equal(_A(200));
+      const newPolicyEvt = getTransactionEvent(pool.interface, receipt, "NewPolicy");
+      const policyId = newPolicyEvt.args[1].id;
+      expect(await pool.ownerOf(policyId)).to.be.equal(cfLender.address);
+
+      await cfLender.connect(resolver).resolvePolicy(newPolicyEvt.args[1], _A(800));
+      expect(await cfLender.currentDebt()).to.be.equal(_A(0));
+      expect(await currency.balanceOf(cfLender.address)).to.be.equal(_A(1000)); // 200 debt repaid
+      expect(await currency.balanceOf(cust.address)).to.be.equal(_A(500 + 600)); // 500 initial + 600 (800-200)
+    });
+
+    ["newPolicy", "newPolicyFull", "newPolicyPaidByHolder"].map((method) => {
+      it(_tn(`Rejects if called by unauthorized user - ${method}`), async () => {
+        const { rm, cfLender } = await helpers.loadFixture(variant.fixture);
+        const policyParams = await defaultPolicyParams({ rmAddress: rm.address, premium: _A(200) });
+        const quoteMessage = makeQuoteMessage(policyParams);
+        const signature = ethers.utils.splitSignature(await signer.signMessage(ethers.utils.arrayify(quoteMessage)));
+        await expect(newPolicy(cfLender, anon, policyParams, cust, signature, method)).to.be.revertedWith(
+          accessControlMessage(anon.address, null, "POLICY_CREATOR_ROLE")
+        );
+      });
+    });
+
+    it(_tn("Rejects if resolved by unauthorized user"), async () => {
+      const { rm, currency, pool, cfLender } = await helpers.loadFixture(variant.fixture);
+      const policyParams = await defaultPolicyParams({ rmAddress: rm.address, premium: _A(200) });
+      const quoteMessage = makeQuoteMessage(policyParams);
+      const signature = ethers.utils.splitSignature(await signer.signMessage(ethers.utils.arrayify(quoteMessage)));
+      await currency.connect(owner).transfer(cfLender.address, _A(1000));
+      const tx = await newPolicy(cfLender, creator, policyParams, cust, signature);
+      const receipt = await tx.wait();
+      expect(await currency.balanceOf(cfLender.address)).to.be.equal(_A(800)); // 200 spent on the premium
+      expect(await cfLender.currentDebt()).to.be.equal(_A(200));
+      const newPolicyEvt = getTransactionEvent(pool.interface, receipt, "NewPolicy");
+      await expect(cfLender.connect(anon).resolvePolicy(newPolicyEvt.args[1], _A(800))).to.be.revertedWith(
+        accessControlMessage(anon.address, null, "RESOLVER_ROLE")
+      );
+    });
+
+    it(_tn("Test no payout to customer because outstanding debt"), async () => {
+      const { rm, pool, currency, cfLender } = await helpers.loadFixture(variant.fixture);
+      let policyParams = await defaultPolicyParams({ rmAddress: rm.address, premium: _A(200) });
+      let quoteMessage = makeQuoteMessage(policyParams);
+      let signature = ethers.utils.splitSignature(await signer.signMessage(ethers.utils.arrayify(quoteMessage)));
+      await currency.connect(owner).transfer(cfLender.address, _A(1000));
+      let tx = await newPolicy(cfLender, creator, policyParams, cust, signature);
+      let receipt = await tx.wait();
+      expect(await cfLender.currentDebt()).to.be.equal(_A(200));
+      let newPolicyEvt = getTransactionEvent(pool.interface, receipt, "NewPolicy");
+      await expect(cfLender.connect(resolver).resolvePolicy(newPolicyEvt.args[1], _A(150)))
+        .to.emit(cfLender, "DebtChanged")
+        .withArgs(_A(50));
+      expect(await cfLender.currentDebt()).to.be.equal(_A(50));
+      expect(await currency.balanceOf(cust.address)).to.be.equal(_A(500)); // 500 initial
+
+      // 2nd Policy
+      policyParams = await defaultPolicyParams({
+        rmAddress: rm.address,
+        premium: _A(100),
+        payout: _A(500),
+        policyData: "0x2cbef6744ebcff4969e06c41631a1d0aa71366c4fd997e9ff5a59b8efa9b9032",
+      });
+      quoteMessage = makeQuoteMessage(policyParams);
+      signature = ethers.utils.splitSignature(await signer.signMessage(ethers.utils.arrayify(quoteMessage)));
+      tx = await newPolicy(cfLender, creator, policyParams, cust, signature, "newPolicyFull");
+      receipt = await tx.wait();
+      expect(await cfLender.currentDebt()).to.be.equal(_A(150));
+      newPolicyEvt = getTransactionEvent(pool.interface, receipt, "NewPolicy");
+
+      await expect(cfLender.connect(anon).resolvePolicyFullPayout(newPolicyEvt.args[1], true)).to.be.revertedWith(
+        accessControlMessage(anon.address, null, "RESOLVER_ROLE")
+      );
+
+      await expect(cfLender.connect(resolver).resolvePolicyFullPayout(newPolicyEvt.args[1], true))
+        .to.emit(cfLender, "DebtChanged")
+        .withArgs(_A(0));
+      expect(await currency.balanceOf(cust.address)).to.be.equal(_A(500 + 500 - 150));
+    });
+
+    it(_tn("Repay debt then payout goes to customer"), async () => {
+      const { rm, pool, currency, cfLender } = await helpers.loadFixture(variant.fixture);
+      let policyParams = await defaultPolicyParams({ rmAddress: rm.address, premium: _A(200) });
+      let quoteMessage = makeQuoteMessage(policyParams);
+      let signature = ethers.utils.splitSignature(await signer.signMessage(ethers.utils.arrayify(quoteMessage)));
+      await currency.connect(owner).transfer(cfLender.address, _A(1000));
+      let tx = await newPolicy(cfLender, creator, policyParams, cust, signature);
+      let receipt = await tx.wait();
+      expect(await cfLender.currentDebt()).to.be.equal(_A(200));
+      let newPolicyEvt = getTransactionEvent(pool.interface, receipt, "NewPolicy");
+      // Repay debt
+      await currency.connect(cust).approve(cfLender.address, _A(500));
+      await expect(cfLender.connect(cust).repayDebt(_A(500)))
+        .to.emit(cfLender, "DebtChanged")
+        .withArgs(_A(0));
+      expect(await cfLender.currentDebt()).to.be.equal(_A(0));
+      expect(await currency.balanceOf(cust.address)).to.be.equal(_A(300)); // 500 initial - 200 repaid
+      await expect(cfLender.connect(resolver).resolvePolicy(newPolicyEvt.args[1], _A(150))).not.to.emit(
+        cfLender,
+        "DebtChanged"
+      );
+      expect(await currency.balanceOf(cust.address)).to.be.equal(_A(450));
+    });
+
+    it(_tn("Repay debt works even if resolved through RM directly"), async () => {
+      const { rm, pool, currency, cfLender, accessManager } = await helpers.loadFixture(variant.fixture);
+      let policyParams = await defaultPolicyParams({ rmAddress: rm.address, premium: _A(200) });
+      let quoteMessage = makeQuoteMessage(policyParams);
+      let signature = ethers.utils.splitSignature(await signer.signMessage(ethers.utils.arrayify(quoteMessage)));
+      await currency.connect(owner).transfer(cfLender.address, _A(1000));
+      let tx = await newPolicy(cfLender, creator, policyParams, cust, signature);
+      let receipt = await tx.wait();
+      expect(await cfLender.currentDebt()).to.be.equal(_A(200));
+      let newPolicyEvt = getTransactionEvent(pool.interface, receipt, "NewPolicy");
+      // Resolve with cust address
+      await accessManager.grantComponentRole(rm.address, await rm.RESOLVER_ROLE(), resolver.address);
+      await expect(rm.connect(resolver).resolvePolicy(newPolicyEvt.args[1], _A(250)))
+        .to.emit(cfLender, "DebtChanged")
+        .withArgs(_A(0));
+      expect(await currency.balanceOf(cust.address)).to.be.equal(_A(550));
+      expect(await cfLender.riskModule()).to.be.equal(rm.address);
+    });
+
+    it(_tn("Checks policy expires OK"), async () => {
+      const { rm, pool, currency, cfLender } = await helpers.loadFixture(variant.fixture);
+      let policyParams = await defaultPolicyParams({ rmAddress: rm.address, premium: _A(200) });
+      let quoteMessage = makeQuoteMessage(policyParams);
+      let signature = ethers.utils.splitSignature(await signer.signMessage(ethers.utils.arrayify(quoteMessage)));
+      await currency.connect(owner).transfer(cfLender.address, _A(1000));
+      let tx = await newPolicy(cfLender, creator, policyParams, cust, signature);
+      let receipt = await tx.wait();
+      expect(await cfLender.currentDebt()).to.be.equal(_A(200));
+      let newPolicyEvt = getTransactionEvent(pool.interface, receipt, "NewPolicy");
+      //
+      await helpers.time.increaseTo(newPolicyEvt.args[1].expiration + 500);
+      // Expire the policy
+      await expect(pool.expirePolicy(newPolicyEvt.args[1])).not.to.emit(cfLender, "DebtChanged");
+      expect(await cfLender.currentDebt()).to.be.equal(_A(200));
+    });
+
+    it(_tn("It's possible to change the customer address and other receives the payout"), async () => {
+      const { rm, pool, currency, cfLender } = await helpers.loadFixture(variant.fixture);
+      let policyParams = await defaultPolicyParams({ rmAddress: rm.address, premium: _A(200) });
+      let quoteMessage = makeQuoteMessage(policyParams);
+      let signature = ethers.utils.splitSignature(await signer.signMessage(ethers.utils.arrayify(quoteMessage)));
+      await currency.connect(owner).transfer(cfLender.address, _A(1000));
+      let tx = await newPolicy(cfLender, creator, policyParams, cust, signature);
+      let receipt = await tx.wait();
+      expect(await cfLender.currentDebt()).to.be.equal(_A(200));
+      let newPolicyEvt = getTransactionEvent(pool.interface, receipt, "NewPolicy");
+
+      // Try changing the customer with anon
+      await expect(cfLender.connect(anon).setCustomer(anon.address)).to.be.revertedWith(
+        accessControlMessage(anon.address, null, "OWNER_ROLE")
+      );
+      await expect(cfLender.connect(owner).setCustomer(anon.address))
+        .to.emit(cfLender, "CustomerChanged")
+        .withArgs(anon.address);
+      expect(await cfLender.customer()).to.be.equal(anon.address);
+      await expect(cfLender.connect(resolver).resolvePolicy(newPolicyEvt.args[1], _A(500)))
+        .to.emit(cfLender, "DebtChanged")
+        .withArgs(_W(0));
+      expect(await currency.balanceOf(cust.address)).to.be.equal(_A(500)); // unchanged
+      expect(await currency.balanceOf(anon.address)).to.be.equal(_A(300)); // 500 payout - 200 debt
+    });
+
+    it(_tn("Test only the owner can withdraw the funds"), async () => {
+      const { rm, pool, currency, cfLender } = await helpers.loadFixture(variant.fixture);
+      let policyParams = await defaultPolicyParams({ rmAddress: rm.address, premium: _A(200) });
+      let quoteMessage = makeQuoteMessage(policyParams);
+      let signature = ethers.utils.splitSignature(await signer.signMessage(ethers.utils.arrayify(quoteMessage)));
+      await currency.connect(owner).transfer(cfLender.address, _A(1000));
+      let tx = await newPolicy(cfLender, creator, policyParams, cust, signature, "newPolicyPaidByHolder");
+      let receipt = await tx.wait();
+      expect(await cfLender.currentDebt()).to.be.equal(_A(200));
+      let newPolicyEvt = getTransactionEvent(pool.interface, receipt, "NewPolicy");
+
+      // Try changing the customer with anon
+      await expect(cfLender.connect(anon).withdraw(_A(200), anon.address)).to.be.revertedWith(
+        accessControlMessage(anon.address, null, "OWNER_ROLE")
+      );
+      await expect(cfLender.connect(owner).withdraw(_A(300), anon.address))
+        .to.emit(cfLender, "Withdrawal")
+        .withArgs(anon.address, _A(300));
+      expect(await currency.balanceOf(anon.address)).to.be.equal(_A(300));
+      expect(await currency.balanceOf(cfLender.address)).to.be.equal(_A(1000 - 300 - 200));
+      await expect(cfLender.connect(resolver).resolvePolicy(newPolicyEvt.args[1], _A(200)))
+        .to.emit(cfLender, "DebtChanged")
+        .withArgs(_A(0));
+      await expect(cfLender.connect(owner).withdraw(ethers.constants.MaxUint256, anon.address))
+        .to.emit(cfLender, "Withdrawal")
+        .withArgs(anon.address, _A(700));
+      expect(await currency.balanceOf(anon.address)).to.be.equal(_A(1000));
+      expect(await currency.balanceOf(cfLender.address)).to.be.equal(_A(0));
+      // When no more funds, withdraw doesn't fails, just doesn't do anything
+      await expect(cfLender.connect(owner).withdraw(ethers.constants.MaxUint256, anon.address)).not.to.emit(
+        cfLender,
+        "Withdrawal"
+      );
+    });
+  });
+
+  it("Creates a policy paid by the MultiRMCashFlowLender with two different RMs", async () => {
+    const { rm, pool, currency, cfLender, premiumsAccount, SignedQuoteRiskModule, accessManager } =
+      await helpers.loadFixture(deployPoolAndCFLFixtureMultiRMCashFlowLender);
+    // Fund the CFL
+    await currency.connect(owner).transfer(cfLender.address, _A(1000));
+    // Create a policy with the first RM
     const policyParams = await defaultPolicyParams({ rmAddress: rm.address, premium: _A(200) });
     const quoteMessage = makeQuoteMessage(policyParams);
     const signature = ethers.utils.splitSignature(await signer.signMessage(ethers.utils.arrayify(quoteMessage)));
-    await expect(newPolicy(cfLender, creator, policyParams, cust, signature)).to.be.revertedWith(
-      "ERC20: transfer amount exceeds balance" // No funds in cfLender
-    );
-    expect(await currency.balanceOf(cfLender.address)).to.be.equal(_A(0));
-    await currency.connect(owner).transfer(cfLender.address, _A(1000));
     const tx = await newPolicy(cfLender, creator, policyParams, cust, signature);
     const receipt = await tx.wait();
     expect(await currency.balanceOf(cfLender.address)).to.be.equal(_A(800)); // 200 spent on the premium
@@ -130,192 +400,82 @@ describe("CashFlowLender contract tests", function () {
     const policyId = newPolicyEvt.args[1].id;
     expect(await pool.ownerOf(policyId)).to.be.equal(cfLender.address);
 
-    await cfLender.connect(resolver).resolvePolicy(newPolicyEvt.args[1], _A(800));
-    expect(await cfLender.currentDebt()).to.be.equal(_A(0));
-    expect(await currency.balanceOf(cfLender.address)).to.be.equal(_A(1000)); // 200 debt repaid
-    expect(await currency.balanceOf(cust.address)).to.be.equal(_A(500 + 600)); // 500 initial + 600 (800-200)
-  });
-
-  it("Rejects if called by unauthorized user", async () => {
-    const { rm, cfLender } = await helpers.loadFixture(deployPoolFixture);
-    const policyParams = await defaultPolicyParams({ rmAddress: rm.address, premium: _A(200) });
-    const quoteMessage = makeQuoteMessage(policyParams);
-    const signature = ethers.utils.splitSignature(await signer.signMessage(ethers.utils.arrayify(quoteMessage)));
-    await expect(newPolicy(cfLender, anon, policyParams, cust, signature)).to.be.revertedWith(
-      accessControlMessage(anon.address, null, "POLICY_CREATOR_ROLE")
-    );
-  });
-
-  it("Rejects if resolved by unauthorized user", async () => {
-    const { rm, currency, pool, cfLender } = await helpers.loadFixture(deployPoolFixture);
-    const policyParams = await defaultPolicyParams({ rmAddress: rm.address, premium: _A(200) });
-    const quoteMessage = makeQuoteMessage(policyParams);
-    const signature = ethers.utils.splitSignature(await signer.signMessage(ethers.utils.arrayify(quoteMessage)));
-    await currency.connect(owner).transfer(cfLender.address, _A(1000));
-    const tx = await newPolicy(cfLender, creator, policyParams, cust, signature);
-    const receipt = await tx.wait();
-    expect(await currency.balanceOf(cfLender.address)).to.be.equal(_A(800)); // 200 spent on the premium
-    expect(await cfLender.currentDebt()).to.be.equal(_A(200));
-    const newPolicyEvt = getTransactionEvent(pool.interface, receipt, "NewPolicy");
-    await expect(cfLender.connect(anon).resolvePolicy(newPolicyEvt.args[1], _A(800))).to.be.revertedWith(
-      accessControlMessage(anon.address, null, "RESOLVER_ROLE")
-    );
-  });
-
-  it("Test no payout to customer because outstanding debt", async () => {
-    const { rm, pool, currency, cfLender } = await helpers.loadFixture(deployPoolFixture);
-    let policyParams = await defaultPolicyParams({ rmAddress: rm.address, premium: _A(200) });
-    let quoteMessage = makeQuoteMessage(policyParams);
-    let signature = ethers.utils.splitSignature(await signer.signMessage(ethers.utils.arrayify(quoteMessage)));
-    await currency.connect(owner).transfer(cfLender.address, _A(1000));
-    let tx = await newPolicy(cfLender, creator, policyParams, cust, signature);
-    let receipt = await tx.wait();
-    expect(await cfLender.currentDebt()).to.be.equal(_A(200));
-    let newPolicyEvt = getTransactionEvent(pool.interface, receipt, "NewPolicy");
-    await expect(cfLender.connect(resolver).resolvePolicy(newPolicyEvt.args[1], _A(150)))
-      .to.emit(cfLender, "DebtChanged")
-      .withArgs(_A(50));
-    expect(await cfLender.currentDebt()).to.be.equal(_A(50));
-    expect(await currency.balanceOf(cust.address)).to.be.equal(_A(500)); // 500 initial
-
-    // 2nd Policy
-    policyParams = await defaultPolicyParams({
-      rmAddress: rm.address,
-      premium: _A(100),
-      payout: _A(500),
-      policyData: "0x2cbef6744ebcff4969e06c41631a1d0aa71366c4fd997e9ff5a59b8efa9b9032",
+    // Setup a new risk module
+    const newRM = await addRiskModule(pool, premiumsAccount, SignedQuoteRiskModule, {
+      ensuroFee: 0.03,
+      extraConstructorArgs: [true],
     });
-    quoteMessage = makeQuoteMessage(policyParams);
-    signature = ethers.utils.splitSignature(await signer.signMessage(ethers.utils.arrayify(quoteMessage)));
-    tx = await newPolicy(cfLender, creator, policyParams, cust, signature, "newPolicyFull");
-    receipt = await tx.wait();
-    expect(await cfLender.currentDebt()).to.be.equal(_A(150));
-    newPolicyEvt = getTransactionEvent(pool.interface, receipt, "NewPolicy");
 
-    await expect(cfLender.connect(resolver).resolvePolicyFullPayout(newPolicyEvt.args[1], true))
-      .to.emit(cfLender, "DebtChanged")
-      .withArgs(_A(0));
-    expect(await currency.balanceOf(cust.address)).to.be.equal(_A(500 + 500 - 150));
-  });
+    expect(await cfLender.connect(owner).riskModule()).to.be.equal(rm.address);
+    await accessManager.grantComponentRole(newRM.address, await newRM.PRICER_ROLE(), signer.address);
+    await accessManager.grantComponentRole(newRM.address, await newRM.RESOLVER_ROLE(), cfLender.address);
+    await cfLender.grantRole(await cfLender.ACTIVE_RM_ADMIN_ROLE(), owner.address);
+    await expect(cfLender.connect(owner).setActiveRiskModule(newRM.address))
+      .to.emit(cfLender, "ActiveRiskModuleChanged")
+      .withArgs(newRM.address);
+    expect(await cfLender.connect(owner).riskModule()).to.be.equal(newRM.address);
 
-  it("Repay debt then payout goes to customer", async () => {
-    const { rm, pool, currency, cfLender } = await helpers.loadFixture(deployPoolFixture);
-    let policyParams = await defaultPolicyParams({ rmAddress: rm.address, premium: _A(200) });
-    let quoteMessage = makeQuoteMessage(policyParams);
-    let signature = ethers.utils.splitSignature(await signer.signMessage(ethers.utils.arrayify(quoteMessage)));
-    await currency.connect(owner).transfer(cfLender.address, _A(1000));
-    let tx = await newPolicy(cfLender, creator, policyParams, cust, signature);
-    let receipt = await tx.wait();
-    expect(await cfLender.currentDebt()).to.be.equal(_A(200));
-    let newPolicyEvt = getTransactionEvent(pool.interface, receipt, "NewPolicy");
-    // Repay debt
-    await currency.connect(cust).approve(cfLender.address, _A(500));
-    await expect(cfLender.connect(cust).repayDebt(_A(500)))
-      .to.emit(cfLender, "DebtChanged")
-      .withArgs(_A(0));
+    // Create a policy with the new RM
+    const policyParams2 = await defaultPolicyParams({ rmAddress: newRM.address, premium: _A(150) });
+    const quoteMessage2 = makeQuoteMessage(policyParams2);
+    const signature2 = ethers.utils.splitSignature(await signer.signMessage(ethers.utils.arrayify(quoteMessage2)));
+    const tx2 = await newPolicy(cfLender, creator, policyParams2, cust, signature2);
+    const receipt2 = await tx2.wait();
+    expect(await currency.balanceOf(cfLender.address)).to.be.equal(_A(650)); // 200+150 spent on the premium
+    expect(await cfLender.currentDebt()).to.be.equal(_A(350));
+    const newPolicyEvt2 = getTransactionEvent(pool.interface, receipt2, "NewPolicy");
+    expect(newPolicyEvt2.args[0]).to.be.equal(newRM.address); // Check was created in the new RM
+    const policyId2 = newPolicyEvt2.args[1].id;
+    expect(await pool.ownerOf(policyId2)).to.be.equal(cfLender.address);
+
+    // Resolve 1st policy, works fine
+    await cfLender.connect(resolver).resolvePolicy(newPolicyEvt.args[1], _A(300));
+    expect(await cfLender.currentDebt()).to.be.equal(_A(50)); // 350 - 300
+    expect(await currency.balanceOf(cfLender.address)).to.be.equal(_A(950)); // debt partially repaid
+    expect(await currency.balanceOf(cust.address)).to.be.equal(_A(500)); // 500 initial unchanged
+
+    // Resolve 2nd policy, works fine too
+    await cfLender.connect(resolver).resolvePolicy(newPolicyEvt2.args[1], _A(500));
     expect(await cfLender.currentDebt()).to.be.equal(_A(0));
-    expect(await currency.balanceOf(cust.address)).to.be.equal(_A(300)); // 500 initial - 200 repaid
-    await expect(cfLender.connect(resolver).resolvePolicy(newPolicyEvt.args[1], _A(150))).not.to.emit(
-      cfLender,
-      "DebtChanged"
-    );
-    expect(await currency.balanceOf(cust.address)).to.be.equal(_A(450));
+    expect(await currency.balanceOf(cfLender.address)).to.be.equal(_A(1000)); // debt fully repaid
+    expect(await currency.balanceOf(cust.address)).to.be.equal(_A(500 + 450)); // 500 initial + 450 (500-50)
   });
 
-  it("Repay debt works even if resolved through RM directly", async () => {
-    const { rm, pool, currency, cfLender, accessManager } = await helpers.loadFixture(deployPoolFixture);
-    let policyParams = await defaultPolicyParams({ rmAddress: rm.address, premium: _A(200) });
-    let quoteMessage = makeQuoteMessage(policyParams);
-    let signature = ethers.utils.splitSignature(await signer.signMessage(ethers.utils.arrayify(quoteMessage)));
-    await currency.connect(owner).transfer(cfLender.address, _A(1000));
-    let tx = await newPolicy(cfLender, creator, policyParams, cust, signature);
-    let receipt = await tx.wait();
-    expect(await cfLender.currentDebt()).to.be.equal(_A(200));
-    let newPolicyEvt = getTransactionEvent(pool.interface, receipt, "NewPolicy");
-    // Resolve with cust address
-    await accessManager.grantComponentRole(rm.address, await rm.RESOLVER_ROLE(), resolver.address);
-    await expect(rm.connect(resolver).resolvePolicy(newPolicyEvt.args[1], _A(250)))
-      .to.emit(cfLender, "DebtChanged")
-      .withArgs(_A(0));
-    expect(await currency.balanceOf(cust.address)).to.be.equal(_A(550));
-    expect(await cfLender.riskModule()).to.be.equal(rm.address);
-  });
-
-  it("Checks policy expires OK", async () => {
-    const { rm, pool, currency, cfLender } = await helpers.loadFixture(deployPoolFixture);
-    let policyParams = await defaultPolicyParams({ rmAddress: rm.address, premium: _A(200) });
-    let quoteMessage = makeQuoteMessage(policyParams);
-    let signature = ethers.utils.splitSignature(await signer.signMessage(ethers.utils.arrayify(quoteMessage)));
-    await currency.connect(owner).transfer(cfLender.address, _A(1000));
-    let tx = await newPolicy(cfLender, creator, policyParams, cust, signature);
-    let receipt = await tx.wait();
-    expect(await cfLender.currentDebt()).to.be.equal(_A(200));
-    let newPolicyEvt = getTransactionEvent(pool.interface, receipt, "NewPolicy");
-    //
-    await helpers.time.increaseTo(newPolicyEvt.args[1].expiration + 500);
-    // Expire the policy
-    await expect(pool.expirePolicy(newPolicyEvt.args[1])).not.to.emit(cfLender, "DebtChanged");
-    expect(await cfLender.currentDebt()).to.be.equal(_A(200));
-  });
-
-  it("It's possible to change the customer address and other receives the payout", async () => {
-    const { rm, pool, currency, cfLender } = await helpers.loadFixture(deployPoolFixture);
-    let policyParams = await defaultPolicyParams({ rmAddress: rm.address, premium: _A(200) });
-    let quoteMessage = makeQuoteMessage(policyParams);
-    let signature = ethers.utils.splitSignature(await signer.signMessage(ethers.utils.arrayify(quoteMessage)));
-    await currency.connect(owner).transfer(cfLender.address, _A(1000));
-    let tx = await newPolicy(cfLender, creator, policyParams, cust, signature);
-    let receipt = await tx.wait();
-    expect(await cfLender.currentDebt()).to.be.equal(_A(200));
-    let newPolicyEvt = getTransactionEvent(pool.interface, receipt, "NewPolicy");
-
-    // Try changing the customer with anon
-    await expect(cfLender.connect(anon).setCustomer(anon.address)).to.be.revertedWith(
-      accessControlMessage(anon.address, null, "OWNER_ROLE")
+  it("MultiRMCashFlowLender.setActiveRiskModule make sure pool unchanged", async () => {
+    const { rm, pool, cfLender, premiumsAccount, SignedQuoteRiskModule } = await helpers.loadFixture(
+      deployPoolAndCFLFixtureMultiRMCashFlowLender
     );
-    await expect(cfLender.connect(owner).setCustomer(anon.address))
-      .to.emit(cfLender, "CustomerChanged")
-      .withArgs(anon.address);
-    expect(await cfLender.customer()).to.be.equal(anon.address);
-    await expect(cfLender.connect(resolver).resolvePolicy(newPolicyEvt.args[1], _A(500)))
-      .to.emit(cfLender, "DebtChanged")
-      .withArgs(_W(0));
-    expect(await currency.balanceOf(cust.address)).to.be.equal(_A(500)); // unchanged
-    expect(await currency.balanceOf(anon.address)).to.be.equal(_A(300)); // 500 payout - 200 debt
-  });
 
-  it("Test only the owner can withdraw the funds", async () => {
-    const { rm, pool, currency, cfLender } = await helpers.loadFixture(deployPoolFixture);
-    let policyParams = await defaultPolicyParams({ rmAddress: rm.address, premium: _A(200) });
-    let quoteMessage = makeQuoteMessage(policyParams);
-    let signature = ethers.utils.splitSignature(await signer.signMessage(ethers.utils.arrayify(quoteMessage)));
-    await currency.connect(owner).transfer(cfLender.address, _A(1000));
-    let tx = await newPolicy(cfLender, creator, policyParams, cust, signature, "newPolicyPaidByHolder");
-    let receipt = await tx.wait();
-    expect(await cfLender.currentDebt()).to.be.equal(_A(200));
-    let newPolicyEvt = getTransactionEvent(pool.interface, receipt, "NewPolicy");
+    expect(await cfLender.connect(owner).riskModule()).to.be.equal(rm.address);
 
-    // Try changing the customer with anon
-    await expect(cfLender.connect(anon).withdraw(_A(200), anon.address)).to.be.revertedWith(
-      accessControlMessage(anon.address, null, "OWNER_ROLE")
+    const otherPoolSetup = await deployPoolFixture(true);
+    expect(pool.address).not.to.be.equal(otherPoolSetup.pool.address);
+
+    await expect(cfLender.connect(anon).setActiveRiskModule(otherPoolSetup.rm.address)).to.be.revertedWith(
+      accessControlMessage(anon.address, null, "ACTIVE_RM_ADMIN_ROLE")
     );
-    await expect(cfLender.connect(owner).withdraw(_A(300), anon.address))
-      .to.emit(cfLender, "Withdrawal")
-      .withArgs(anon.address, _A(300));
-    expect(await currency.balanceOf(anon.address)).to.be.equal(_A(300));
-    expect(await currency.balanceOf(cfLender.address)).to.be.equal(_A(1000 - 300 - 200));
-    await expect(cfLender.connect(resolver).resolvePolicy(newPolicyEvt.args[1], _A(200)))
-      .to.emit(cfLender, "DebtChanged")
-      .withArgs(_A(0));
-    await expect(cfLender.connect(owner).withdraw(ethers.constants.MaxUint256, anon.address))
-      .to.emit(cfLender, "Withdrawal")
-      .withArgs(anon.address, _A(700));
-    expect(await currency.balanceOf(anon.address)).to.be.equal(_A(1000));
-    expect(await currency.balanceOf(cfLender.address)).to.be.equal(_A(0));
-    // When no more funds, withdraw doesn't fails, just doesn't do anything
-    await expect(cfLender.connect(owner).withdraw(ethers.constants.MaxUint256, anon.address)).not.to.emit(
-      cfLender,
-      "Withdrawal"
+
+    await cfLender.grantRole(await cfLender.ACTIVE_RM_ADMIN_ROLE(), owner.address);
+
+    await expect(cfLender.connect(owner).setActiveRiskModule(otherPoolSetup.rm.address)).to.be.revertedWith(
+      "The new risk module has to be part of the same pool"
     );
+
+    // Setup a new risk module
+    const newRM = await addRiskModule(pool, premiumsAccount, SignedQuoteRiskModule, {
+      ensuroFee: 0.03,
+      extraConstructorArgs: [true],
+    });
+
+    await expect(cfLender.connect(owner).setActiveRiskModule(newRM.address))
+      .to.emit(cfLender, "ActiveRiskModuleChanged")
+      .withArgs(newRM.address);
+    expect(await cfLender.connect(owner).riskModule()).to.be.equal(newRM.address);
+
+    // Setting back address(0) is also possible, then goes back to original RM
+    await expect(cfLender.connect(owner).setActiveRiskModule(ethers.constants.AddressZero))
+      .to.emit(cfLender, "ActiveRiskModuleChanged")
+      .withArgs(rm.address);
+    expect(await cfLender.connect(owner).riskModule()).to.be.equal(rm.address);
   });
 });

--- a/test/test-storage-gaps.js
+++ b/test/test-storage-gaps.js
@@ -3,7 +3,7 @@ const { expect } = require("chai");
 const { getStorageLayout } = require("@ensuro/core/js/test-utils");
 
 describe("Storage Gaps", () => {
-  const contracts = ["CashFlowLender", "QuadrataWhitelist"];
+  const contracts = ["CashFlowLender", "QuadrataWhitelist", "MultiRMCashFlowLender"];
 
   for (const contract of contracts) {
     it(`${contract} has a proper storage gap`, async () => {


### PR DESCRIPTION
Subclass of CashFlowLender that allows changing the active risk module and sending new policies to a new risk module.

Policy resolution sends the resolvePolicy to the risk module that comes in the policy struct parameter.