### PR TITLE
[EXPERIMENT] Integrate foundry into the project

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,6 +14,7 @@ jobs:
         with:
           node-version: "20"
           cache: "npm"
+      - uses: foundry-rs/foundry-toolchain@v1
       - run: npm ci
       - run: npx hardhat compile
       - run: npx hardhat size-contracts

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,9 @@ cache
 artifacts
 build
 
+# foundry files
+cache_forge
+out
+
 .openzeppelin
 .DS_Store

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lib/forge-std"]
+	path = lib/forge-std
+	url = https://github.com/foundry-rs/forge-std

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,0 +1,6 @@
+[profile.default]
+src = 'contracts'
+out = 'out'
+libs = ['node_modules', 'lib']
+test = 'test'
+cache_path  = 'cache_forge'

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -10,8 +10,14 @@ require("@nomicfoundation/hardhat-foundry");
 
 // const exec = require("util").promisify(require("child_process").exec);
 const { execSync } = require("child_process");
-const { task } = require("hardhat/config");
+const { extendConfig, task } = require("hardhat/config");
 const { TASK_TEST } = require("hardhat/builtin-tasks/task-names");
+
+// Workaround https://github.com/ItsNickBarry/hardhat-dependency-compiler/issues/16
+const path = require("path");
+extendConfig((config) => {
+  config.paths.sources = path.resolve(config.paths.sources);
+});
 
 task(TASK_TEST, async function (args, hre, runSuper) {
   // Run forge tests

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -6,6 +6,20 @@ require("@openzeppelin/hardhat-upgrades");
 require("hardhat-dependency-compiler");
 require("hardhat-contract-sizer");
 require("solidity-coverage");
+require("@nomicfoundation/hardhat-foundry");
+
+// const exec = require("util").promisify(require("child_process").exec);
+const { execSync } = require("child_process");
+const { task } = require("hardhat/config");
+const { TASK_TEST } = require("hardhat/builtin-tasks/task-names");
+
+task(TASK_TEST, async function (args, hre, runSuper) {
+  // Run forge tests
+  await execSync("forge test", { stdio: "inherit" });
+
+  // Run tests as usual
+  await runSuper();
+});
 
 /** @type import('hardhat/config').HardhatUserConfig */
 module.exports = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "@nomicfoundation/hardhat-chai-matchers": "^2.0.6",
+        "@nomicfoundation/hardhat-foundry": "^1.1.1",
         "@nomicfoundation/hardhat-network-helpers": "^1.0.10",
         "@nomicfoundation/hardhat-toolbox": "^4.0.0",
         "@openzeppelin/hardhat-upgrades": "^3.0.2",
@@ -1544,6 +1545,18 @@
       "peerDependencies": {
         "ethers": "^6.1.0",
         "hardhat": "^2.0.0"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-foundry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-foundry/-/hardhat-foundry-1.1.1.tgz",
+      "integrity": "sha512-cXGCBHAiXas9Pg9MhMOpBVQCkWRYoRFG7GJJAph+sdQsfd22iRs5U5Vs9XmpGEQd1yEvYISQZMeE68Nxj65iUQ==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^2.4.2"
+      },
+      "peerDependencies": {
+        "hardhat": "^2.17.2"
       }
     },
     "node_modules/@nomicfoundation/hardhat-network-helpers": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "devDependencies": {
     "@nomicfoundation/hardhat-chai-matchers": "^2.0.6",
+    "@nomicfoundation/hardhat-foundry": "^1.1.1",
     "@nomicfoundation/hardhat-network-helpers": "^1.0.10",
     "@nomicfoundation/hardhat-toolbox": "^4.0.0",
     "@openzeppelin/hardhat-upgrades": "^3.0.2",
@@ -19,13 +20,13 @@
     "eslint-config-prettier": "^9.1.0",
     "hardhat": "^2.19.5",
     "hardhat-contract-sizer": "^2.10.0",
+    "hardhat-dependency-compiler": "^1.1.3",
     "prettier": "^3.2.5",
     "prettier-plugin-solidity": "^1.3.1",
     "solhint": "^4.1.1",
     "solhint-plugin-prettier": "0.1.0",
     "ts-node": "^10.9.2",
-    "typescript": "^4.8.2",
-    "hardhat-dependency-compiler": "^1.1.3"
+    "typescript": "^4.8.2"
   },
   "dependencies": {
     "@chainlink/contracts": "^0.6.1",

--- a/test/StableSwapPayoutHandler.t.sol
+++ b/test/StableSwapPayoutHandler.t.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.16;
+
+import "forge-std/Test.sol";
+
+import {StableSwapPayoutHandler} from "contracts/StableSwapPayoutHandler.sol";
+import {IPolicyHolder} from "@ensuro/core/contracts/interfaces/IPolicyHolder.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+
+contract TestStableSwapPayoutHandler is Test {
+  StableSwapPayoutHandler payoutHandler;
+
+  function setUp() public {
+    payoutHandler = new StableSwapPayoutHandler(IERC20Metadata(address(20)));
+  }
+
+  function test_SupportsInterface() public {
+    assertTrue(payoutHandler.supportsInterface(type(IPolicyHolder).interfaceId));
+    assertTrue(payoutHandler.supportsInterface(type(IERC721).interfaceId));
+  }
+}


### PR DESCRIPTION
Just a proof of concept to see if it would be practical to integrate foundry in our projects. A few issues:

- ~~Incompatibility with hardhat-dependency-compiler, apparently an [easy fix](https://github.com/ItsNickBarry/hardhat-dependency-compiler/issues/16#issuecomment-2010890852)~~ fixed by mantainer
- Foundry tests don't count for coverage. From [foundry's docs](https://book.getfoundry.sh/reference/forge/forge-test) it doesn't look like the foundry tests can be made to run against the hardhat node (or using the instrumented code for that matter). Maybe it's possible the other way around, but a quick google search suggests no one is doing it.
- It uses git submodules, which suck.

